### PR TITLE
add null checks to server droppart

### DIFF
--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -100,7 +100,7 @@ public sealed class BodySystem : SharedBodySystem
     {
         var oldBody = CompOrNull<BodyPartComponent>(partId)?.Body;
 
-        if (!base.DropPart(partId, part))
+        if (partId == null || !Resolve(partId.Value, ref part, false) || !base.DropPart(partId, part))
             return false;
 
         if (oldBody == null || !TryComp<HumanoidAppearanceComponent>(oldBody, out var humanoid))

--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -79,7 +79,7 @@ public sealed class BodySystem : SharedBodySystem
         BodyPartSlot slot,
         [NotNullWhen(true)] BodyPartComponent? part = null)
     {
-        if (!base.AttachPart(partId, slot, part))
+        if (partId == null || !Resolve(partId.Value, ref part, false) || !base.AttachPart(partId, slot, part))
             return false;
 
         if (part.Body is { } body &&


### PR DESCRIPTION
## About the PR
orphan called with null, shared is not an out so server got null part when it returned true
so added null check and a resolve to server