### PR TITLE
fix add organ to first valid slot logic

### DIFF
--- a/Content.Shared/Body/Systems/SharedBodySystem.Organs.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Organs.cs
@@ -100,10 +100,10 @@ public partial class SharedBodySystem
         foreach (var slot in parent.Organs.Values)
         {
             if (slot.Child == null)
-                continue;
-
-            InsertOrgan(childId, slot, child);
-            return true;
+            {
+                InsertOrgan(childId, slot, child);
+                return true;
+            }
         }
 
         return false;


### PR DESCRIPTION
## About the PR
basically it was inverted so it would only insert to a slot *if it already had an organ*
so now thats fixed and organ transplant surgery works

note: this still does not check if its the right organ for the slot, only if its empty
ill leave that for you to decide, maybe having 2 lungs but no heart is a thing you want supported i dunno