### PR TITLE
Add Unique wounds for woundables

### DIFF
--- a/Content.Shared/Medical/Wounding/Components/WoundComponent.cs
+++ b/Content.Shared/Medical/Wounding/Components/WoundComponent.cs
@@ -33,4 +33,10 @@ public sealed partial class WoundComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
     public FixedPoint2 Severity = 100;
+
+    /// <summary>
+    /// Whether multiple wounds originating from the same prototype can exist on a woundable.
+    /// </summary>
+    [DataField]
+    public bool Unique;
 }

--- a/Content.Shared/Medical/Wounding/Systems/WoundSystem.Wounding.cs
+++ b/Content.Shared/Medical/Wounding/Systems/WoundSystem.Wounding.cs
@@ -79,8 +79,6 @@ public sealed partial class WoundSystem
         {
             // Assumption: Since this wound is unique, then any other wound we are looking for is also unique.
             // So we don't need to try to get the meta component for other wounds that are not unique.
-            // This will lead to a false positive if both meta comps have no associated prototype but if that happens
-            // something else has gone horribly wrong anyways.
             if (otherWound.Comp.Unique &&
                 TryComp<MetaDataComponent>(otherWound.Owner, out var otherMeta) &&
                 otherMeta.EntityPrototype?.ID == woundProto)

--- a/Content.Shared/Medical/Wounding/Systems/WoundSystem.Wounding.cs
+++ b/Content.Shared/Medical/Wounding/Systems/WoundSystem.Wounding.cs
@@ -40,6 +40,59 @@ public sealed partial class WoundSystem
         }
     }
 
+    /// <summary>
+    /// Checks whether adding a wound to a woundable entity would conflict with another wound it currently has.
+    /// </summary>
+    /// <param name="wound">The wound to check against.</param>
+    /// <param name="woundable">The woundable entity</param>
+    /// <param name="conflictingWound">The conflicting wound if found.</param>
+    /// <returns>Returns true if the wound conflicts.</returns>
+    private bool ConflictsWithUniqueWound(Entity<WoundComponent> wound, Entity<WoundableComponent> woundable,
+        [NotNullWhen(true)] out Entity<WoundComponent>? conflictingWound)
+    {
+        conflictingWound = null;
+
+        if (wound.Comp.Unique)
+            return false;
+
+        if (!TryComp<MetaDataComponent>(wound, out var meta) || meta.EntityPrototype == null)
+            return false;
+
+        return ConflictsWithUniqueWound(meta.EntityPrototype.ID, woundable, out conflictingWound);
+    }
+
+    /// <summary>
+    /// Checks whether adding a wound to a woundable entity would conflict with another wound it currently has.
+    /// </summary>
+    /// <param name="woundProto">The name of the wound prototype to check against.</param>
+    /// <param name="woundable">The woundable entity</param>
+    /// <param name="conflictingWound">The conflicting unique wound if found.</param>
+    /// <returns>Returns true if the wound conflicts.</returns>
+    private bool ConflictsWithUniqueWound(string woundProto,
+        Entity<WoundableComponent> woundable,
+        [NotNullWhen(true)] out Entity<WoundComponent>? conflictingWound)
+    {
+        conflictingWound = null;
+        var allWounds = GetAllWounds(woundable);
+
+        foreach (var otherWound in allWounds)
+        {
+            // Assumption: Since this wound is unique, then any other wound we are looking for is also unique.
+            // So we don't need to try to get the meta component for other wounds that are not unique.
+            // This will lead to a false positive if both meta comps have no associated prototype but if that happens
+            // something else has gone horribly wrong anyways.
+            if (otherWound.Comp.Unique &&
+                TryComp<MetaDataComponent>(otherWound.Owner, out var otherMeta) &&
+                otherMeta.EntityPrototype?.ID == woundProto)
+            {
+                conflictingWound = otherWound;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     #endregion
 
 
@@ -104,10 +157,17 @@ public sealed partial class WoundSystem
             //If damage is negative (healing) skip because wound healing is handled with internal logic.
             if (damage < 0)
                 continue;
-            if (!TryGetWoundProtoFromDamage(validWoundable, new(damageTypeId), damage,
-                    out var protoId, out var overflow))
+
+            var gotWound = TryGetWoundProtoFromDamage(validWoundable, new(damageTypeId), damage,
+                out var protoId, out var overflow, out var conflicting);
+
+            if (conflicting != null)
+                SetWoundSeverity(conflicting.Value, 1, true);
+
+            if (!gotWound)
                 return;
-            AddWound(validWoundable, protoId, DefaultSeverity);
+
+            AddWound(validWoundable, protoId!, DefaultSeverity);
         }
     }
 
@@ -167,12 +227,15 @@ public sealed partial class WoundSystem
     /// <param name="damage">Damage being applied</param>
     /// <param name="woundProtoId">Found WoundProtoId</param>
     /// <param name="damageOverflow">The amount of damage exceeding the max cap</param>
+    /// <param name="conflictingWound">A conflicting wound if found. This will not be null when the wound that would
+    /// otherwise be returned was skipped because it would conflict with this wound.</param>
     /// <returns>True if a woundProto is found, false if not</returns>
     public bool TryGetWoundProtoFromDamage(Entity<WoundableComponent> woundable,ProtoId<DamageTypePrototype> damageType, FixedPoint2 damage,
-        [NotNullWhen(true)] out string? woundProtoId, out FixedPoint2 damageOverflow)
+        [NotNullWhen(true)] out string? woundProtoId, out FixedPoint2 damageOverflow, out Entity<WoundComponent>? conflictingWound)
     {
         damageOverflow = 0;
         woundProtoId = null;
+        conflictingWound = null;
         if (!woundable.Comp.Config.TryGetValue(damageType, out var metadata))
             return false;
         //scale the incoming damage and calculate overflows
@@ -184,12 +247,26 @@ public sealed partial class WoundSystem
         }
         var percentageOfMax = adjDamage / metadata.DamageMax *100;
         var woundPool = _prototypeManager.Index(metadata.WoundPool);
+        Entity<WoundComponent>? conflicting = null;
+        var retConflicting = false;
         foreach (var (percentage, lastWoundProtoId) in woundPool.Wounds)
         {
             if (percentage >= percentageOfMax)
                 break;
+
+            if (ConflictsWithUniqueWound(lastWoundProtoId, woundable, out conflicting))
+            {
+                retConflicting = true;
+                continue;
+            }
+
             woundProtoId = lastWoundProtoId;
+            retConflicting = false;
         }
+
+        if (retConflicting)
+            conflictingWound = conflicting;
+
         return woundProtoId != null;
     }
 
@@ -259,6 +336,14 @@ public sealed partial class WoundSystem
         if (!TryComp<WoundableComponent>(args.Container.Owner, out var woundable))
         {
             Log.Error("Tried to add a wound to an entity without a woundable!");
+            args.Cancel();
+            return;
+        }
+
+        if (ConflictsWithUniqueWound(new Entity<WoundComponent>(woundEnt, wound),
+                new Entity<WoundableComponent>(args.Container.Owner, woundable), out _))
+        {
+            Log.Error("Tried to add a wound to entity which would conflict with a unique wound!");
             args.Cancel();
             return;
         }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds singleton wounds. Referred to as unique in the code.

If a wound conflicts with a unique wound when it is being added due to damage, then the next lowest non conflicting wound will be added and the conflicting wound's severity will be reset to 1. The severity does not reset if this is attempted with the wound command.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The check is done in 2 places: 
- OnWoundInsertAttempt() in order to make it impossible for a conflicting wound to be added to a woundable.
- TryGetWoundProtoFromDamage() where it will also return the conflicting wound if it's what led to the function's result. An edge case here: If multiple unique wounds conflict in a row then only the last one will be returned to have its severity reset. Furthermore, because we don't actually have a wound entity for the wound prototypes we are trying we do not know if those wounds are unique. This means that for every wound that is tried, we have to go through every other wound on the woundable to find unique wounds and see if their prototypes match. OnWoundInsertAttempt uses an overload of the function used to check this which immediately returns if the wound that's being inserted isn't unique since we can assume that no wounds of this type are unique. 

Checking is done by ConflictsWithUniqueWound() which returns a boolean indicating if a wound conflicts, and the conflicting wound if found.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
